### PR TITLE
Fix conflict between webcomponents and prototype

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "webcomponentsjs",
   "main": "webcomponents.js",
-  "version": "0.7.22",
+  "version": "0.7.22.1",
   "homepage": "http://webcomponents.org",
   "authors": [
     "The Polymer Authors"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webcomponents.js",
-  "version": "0.7.22",
+  "version": "0.7.22.1",
   "description": "webcomponents.js",
   "main": "webcomponents.js",
   "directories": {

--- a/src/WebComponents/dom.js
+++ b/src/WebComponents/dom.js
@@ -99,6 +99,10 @@
       return e;
     };
     window.Event.prototype = origEvent.prototype;
+    var origMethods = Object.getOwnPropertyNames(origEvent);
+    for (var i = 0; i < origMethods.length; i++) {
+      window.Event[origMethods[i]] = origEvent.origMethods[i];
+    }
   }
 
 })(window.WebComponents);


### PR DESCRIPTION
prototype.js extends global Event object with custom methods. webcomponents re-sets global Event object in IE, which makes prototypejs unusable.
This copies all static methods from original Event object to a new one.

https://github.com/webcomponents/webcomponentsjs/issues/562
