### PR TITLE
Rename `window.wrap` to `window.smWrapElement`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "webcomponentsjs",
   "main": "webcomponents.js",
-  "version": "0.7.22.4",
+  "version": "0.7.22.5",
   "homepage": "http://webcomponents.org",
   "authors": [
     "The Polymer Authors"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webcomponents.js",
-  "version": "0.7.22.4",
+  "version": "0.7.22.5",
   "description": "webcomponents.js",
   "main": "webcomponents.js",
   "directories": {

--- a/src/CustomElements/boot.js
+++ b/src/CustomElements/boot.js
@@ -47,12 +47,12 @@ var upgradeDocument = scope.upgradeDocument;
 
 // ShadowDOM polyfill wraps elements but some elements like `document`
 // cannot be wrapped so we help the polyfill by wrapping some elements.
-if (!window.wrap) {
+if (!window.smWrapElement) {
   if (window.ShadowDOMPolyfill) {
-    window.wrap = window.ShadowDOMPolyfill.wrapIfNeeded;
+    window.smWrapElement = window.ShadowDOMPolyfill.wrapIfNeeded;
     window.unwrap = window.ShadowDOMPolyfill.unwrapIfNeeded;
   } else {
-    window.wrap = window.unwrap = function(node) {
+    window.smWrapElement = window.unwrap = function(node) {
       return node;
     };
   }
@@ -62,7 +62,7 @@ if (!window.wrap) {
 if (window.HTMLImports) {
   window.HTMLImports.__importsParsingHook = function(elt) {
     if (elt.import) {
-      upgradeDocument(wrap(elt.import));
+      upgradeDocument(smWrapElement(elt.import));
     }
   };
 }
@@ -70,7 +70,7 @@ if (window.HTMLImports) {
 // bootstrap parsing
 function bootstrap() {
   // one more upgrade to catch out of order registrations
-  upgradeDocumentTree(window.wrap(document));
+  upgradeDocumentTree(window.smWrapElement(document));
   // install upgrade hook if HTMLImports are available
   // set internal 'ready' flag, now document.registerElement will trigger
   // synchronous upgrades

--- a/src/CustomElements/observe.js
+++ b/src/CustomElements/observe.js
@@ -152,7 +152,7 @@ function _detached(element) {
 // recurse up the tree to check if an element is actually in the main document.
 function inDocument(element) {
   var p = element;
-  var doc = window.wrap(document);
+  var doc = window.smWrapElement(document);
   while (p) {
     if (p == doc) {
       return true;
@@ -242,10 +242,10 @@ function handler(root, mutations) {
   pending upgrades and attached/detached callbacks synchronously.
 */
 function takeRecords(node) {
-  node = window.wrap(node);
+  node = window.smWrapElement(node);
   // If the optional node is not supplied, assume we mean the whole document.
   if (!node) {
-    node = window.wrap(document);
+    node = window.smWrapElement(document);
   }
   // Find the root of the tree, which will be an Document or ShadowRoot.
   while (node.parentNode) {
@@ -277,9 +277,9 @@ function observe(inRoot) {
 
 // upgrade an entire document and observe it for elements changes.
 function upgradeDocument(doc) {
-  doc = window.wrap(doc);
+  doc = window.smWrapElement(doc);
   flags.dom && console.group('upgradeDocument: ', (doc.baseURI).split('/').pop());
-  var isMainDocument = (doc === window.wrap(document));
+  var isMainDocument = (doc === window.smWrapElement(document));
   addedNode(doc, isMainDocument);
   observe(doc);
   flags.dom && console.groupEnd();

--- a/src/CustomElements/traverse.js
+++ b/src/CustomElements/traverse.js
@@ -64,7 +64,7 @@ function forDocumentTree(doc, cb) {
 
 
 function _forDocumentTree(doc, cb, processingDocuments) {
-  doc = window.wrap(doc);
+  doc = window.smWrapElement(doc);
   if (processingDocuments.indexOf(doc) >= 0) {
     return;
   }

--- a/src/WebComponents/shadowdom.js
+++ b/src/WebComponents/shadowdom.js
@@ -18,11 +18,11 @@
   */
   // convenient global
   if (window.ShadowDOMPolyfill) {
-    window.wrap = ShadowDOMPolyfill.wrapIfNeeded;
+    window.smWrapElement = ShadowDOMPolyfill.wrapIfNeeded;
     window.unwrap = ShadowDOMPolyfill.unwrapIfNeeded;
   } else {
     // so we can call wrap/unwrap without testing for ShadowDOMPolyfill
-    window.wrap = window.unwrap = function(n) {
+    window.smWrapElement = window.unwrap = function(n) {
       return n;
     };
   }


### PR DESCRIPTION
Element with id `wrap` is also stored at `window.wrap` which causes
`window.wrap` to not be a function, but an element.
This changes the name of the wrap method to be more unique to ensure
that there are no elements whose id is the same.

I tried using rebasing our webcomponents to upstream but that caused
problems with sm.require + their whole structure had changed which now
included even more polyfills. To be sure that we don't break visitor app,
decided to keep using the version that we have been used so far.

The webcomponents library is full of hacks that assigning objects/functions
to window. I hope we can get rid of sm-engaged-operator and 
sm-engaged-visitor widgets sooner than later so that we could stop using
webcomponents library alltogether.

Tested with chrome and the troubled browsers - IE11, Safari 10.

COB-367